### PR TITLE
Get rid of oneOfs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -23,8 +23,8 @@ var (
 
 type SampleProto struct {
 	AllowNullValues    bool
-	AllowEnumOneOf     bool
-	AllowOneOf         bool
+	DisallowEnumOneOf  bool
+	DisallowOneOf      bool
 	ExpectedJsonSchema []string
 	FilesToGenerate    []string
 	ProtoFileName      string
@@ -71,8 +71,8 @@ func testConvertSampleProtos(t *testing.T, sampleProto SampleProto) {
 
 	// Set allowNullValues accordingly:
 	allowNullValues = sampleProto.AllowNullValues
-	allowEnumOneOf = sampleProto.AllowEnumOneOf
-	allowOneOf = sampleProto.AllowOneOf
+	disallowEnumOneOf = sampleProto.DisallowEnumOneOf
+	disallowOneOf = sampleProto.DisallowOneOf
 
 	// Open the sample proto file:
 	sampleProtoFileName := fmt.Sprintf("%v/%v", sampleProtoDirectory, sampleProto.ProtoFileName)
@@ -115,8 +115,6 @@ func configureSampleProtos() {
 	// ArrayOfMessages:
 	sampleProtos["ArrayOfMessages"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage, testdata.ArrayOfMessages},
 		FilesToGenerate:    []string{"ArrayOfMessages.proto", "PayloadMessage.proto"},
 		ProtoFileName:      "ArrayOfMessages.proto",
@@ -125,8 +123,6 @@ func configureSampleProtos() {
 	// ArrayOfEnums
 	sampleProtos["ArrayOfEnums"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ArrayOfEnums},
 		FilesToGenerate:    []string{"ArrayOfEnums.proto"},
 		ProtoFileName:      "ArrayOfEnums.proto",
@@ -135,8 +131,6 @@ func configureSampleProtos() {
 	// ArrayOfObjects:
 	sampleProtos["ArrayOfObjects"] = SampleProto{
 		AllowNullValues:    true,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ArrayOfObjects},
 		FilesToGenerate:    []string{"ArrayOfObjects.proto"},
 		ProtoFileName:      "ArrayOfObjects.proto",
@@ -145,8 +139,6 @@ func configureSampleProtos() {
 	// ArrayOfPrimitives:
 	sampleProtos["ArrayOfPrimitives"] = SampleProto{
 		AllowNullValues:    true,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ArrayOfPrimitives},
 		FilesToGenerate:    []string{"ArrayOfPrimitives.proto"},
 		ProtoFileName:      "ArrayOfPrimitives.proto",
@@ -155,8 +147,6 @@ func configureSampleProtos() {
 	// EnumCeption:
 	sampleProtos["EnumCeption"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage, testdata.ImportedEnum, testdata.EnumCeption},
 		FilesToGenerate:    []string{"Enumception.proto", "PayloadMessage.proto", "ImportedEnum.proto"},
 		ProtoFileName:      "Enumception.proto",
@@ -165,8 +155,8 @@ func configureSampleProtos() {
 	// EnumWithNoOneOf:
 	sampleProtos["EnumWithNoOneOf"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     false,
-		AllowOneOf:         false,
+		DisallowEnumOneOf:  true,
+		DisallowOneOf:      true,
 		ExpectedJsonSchema: []string{testdata.EnumWithNoOneOf},
 		FilesToGenerate:    []string{"EnumWithNoOneOf.proto"},
 		ProtoFileName:      "EnumWithNoOneOf.proto",
@@ -175,8 +165,6 @@ func configureSampleProtos() {
 	// ImportedEnum:
 	sampleProtos["ImportedEnum"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ImportedEnum},
 		FilesToGenerate:    []string{"ImportedEnum.proto"},
 		ProtoFileName:      "ImportedEnum.proto",
@@ -185,8 +173,6 @@ func configureSampleProtos() {
 	// NestedMessage:
 	sampleProtos["NestedMessage"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage, testdata.NestedMessage},
 		FilesToGenerate:    []string{"NestedMessage.proto", "PayloadMessage.proto"},
 		ProtoFileName:      "NestedMessage.proto",
@@ -195,8 +181,6 @@ func configureSampleProtos() {
 	// NestedObject:
 	sampleProtos["NestedObject"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.NestedObject},
 		FilesToGenerate:    []string{"NestedObject.proto"},
 		ProtoFileName:      "NestedObject.proto",
@@ -205,8 +189,8 @@ func configureSampleProtos() {
 	// NoOneOf:
 	sampleProtos["NoOneOf"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     false,
-		AllowOneOf:         false,
+		DisallowEnumOneOf:  true,
+		DisallowOneOf:      true,
 		ExpectedJsonSchema: []string{testdata.NoOneOf},
 		FilesToGenerate:    []string{"NoOneOf.proto"},
 		ProtoFileName:      "NoOneOf.proto",
@@ -215,8 +199,6 @@ func configureSampleProtos() {
 	// PayloadMessage:
 	sampleProtos["PayloadMessage"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage},
 		FilesToGenerate:    []string{"PayloadMessage.proto"},
 		ProtoFileName:      "PayloadMessage.proto",
@@ -225,8 +207,6 @@ func configureSampleProtos() {
 	// SeveralEnums:
 	sampleProtos["SeveralEnums"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.FirstEnum, testdata.SecondEnum},
 		FilesToGenerate:    []string{"SeveralEnums.proto"},
 		ProtoFileName:      "SeveralEnums.proto",
@@ -235,8 +215,6 @@ func configureSampleProtos() {
 	// SeveralMessages:
 	sampleProtos["SeveralMessages"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.FirstMessage, testdata.SecondMessage},
 		FilesToGenerate:    []string{"SeveralMessages.proto"},
 		ProtoFileName:      "SeveralMessages.proto",
@@ -245,8 +223,6 @@ func configureSampleProtos() {
 	// Timestamp
 	sampleProtos["Timestamp"] = SampleProto{
 		AllowNullValues:    false,
-		AllowEnumOneOf:     true,
-		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.Timestamp},
 		FilesToGenerate:    []string{"Timestamp.proto"},
 		ProtoFileName:      "Timestamp.proto",

--- a/main_test.go
+++ b/main_test.go
@@ -23,7 +23,8 @@ var (
 
 type SampleProto struct {
 	AllowNullValues    bool
-	DisallowEnumOneOfs bool
+	AllowEnumOneOf     bool
+	AllowOneOf         bool
 	ExpectedJsonSchema []string
 	FilesToGenerate    []string
 	ProtoFileName      string
@@ -48,6 +49,7 @@ func TestGenerateJsonSchema(t *testing.T) {
 	testConvertSampleProtos(t, sampleProtos["ImportedEnum"])
 	testConvertSampleProtos(t, sampleProtos["NestedMessage"])
 	testConvertSampleProtos(t, sampleProtos["NestedObject"])
+	testConvertSampleProtos(t, sampleProtos["NoOneOf"])
 	testConvertSampleProtos(t, sampleProtos["PayloadMessage"])
 	testConvertSampleProtos(t, sampleProtos["SeveralEnums"])
 	testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
@@ -69,8 +71,8 @@ func testConvertSampleProtos(t *testing.T, sampleProto SampleProto) {
 
 	// Set allowNullValues accordingly:
 	allowNullValues = sampleProto.AllowNullValues
-
-	disallowEnumOneOf = sampleProto.DisallowEnumOneOfs
+	allowEnumOneOf = sampleProto.AllowEnumOneOf
+	allowOneOf = sampleProto.AllowOneOf
 
 	// Open the sample proto file:
 	sampleProtoFileName := fmt.Sprintf("%v/%v", sampleProtoDirectory, sampleProto.ProtoFileName)
@@ -113,6 +115,8 @@ func configureSampleProtos() {
 	// ArrayOfMessages:
 	sampleProtos["ArrayOfMessages"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage, testdata.ArrayOfMessages},
 		FilesToGenerate:    []string{"ArrayOfMessages.proto", "PayloadMessage.proto"},
 		ProtoFileName:      "ArrayOfMessages.proto",
@@ -121,6 +125,8 @@ func configureSampleProtos() {
 	// ArrayOfEnums
 	sampleProtos["ArrayOfEnums"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ArrayOfEnums},
 		FilesToGenerate:    []string{"ArrayOfEnums.proto"},
 		ProtoFileName:      "ArrayOfEnums.proto",
@@ -129,6 +135,8 @@ func configureSampleProtos() {
 	// ArrayOfObjects:
 	sampleProtos["ArrayOfObjects"] = SampleProto{
 		AllowNullValues:    true,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ArrayOfObjects},
 		FilesToGenerate:    []string{"ArrayOfObjects.proto"},
 		ProtoFileName:      "ArrayOfObjects.proto",
@@ -137,6 +145,8 @@ func configureSampleProtos() {
 	// ArrayOfPrimitives:
 	sampleProtos["ArrayOfPrimitives"] = SampleProto{
 		AllowNullValues:    true,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ArrayOfPrimitives},
 		FilesToGenerate:    []string{"ArrayOfPrimitives.proto"},
 		ProtoFileName:      "ArrayOfPrimitives.proto",
@@ -145,6 +155,8 @@ func configureSampleProtos() {
 	// EnumCeption:
 	sampleProtos["EnumCeption"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage, testdata.ImportedEnum, testdata.EnumCeption},
 		FilesToGenerate:    []string{"Enumception.proto", "PayloadMessage.proto", "ImportedEnum.proto"},
 		ProtoFileName:      "Enumception.proto",
@@ -153,7 +165,8 @@ func configureSampleProtos() {
 	// EnumWithNoOneOf:
 	sampleProtos["EnumWithNoOneOf"] = SampleProto{
 		AllowNullValues:    false,
-		DisallowEnumOneOfs: true,
+		AllowEnumOneOf:     false,
+		AllowOneOf:         false,
 		ExpectedJsonSchema: []string{testdata.EnumWithNoOneOf},
 		FilesToGenerate:    []string{"EnumWithNoOneOf.proto"},
 		ProtoFileName:      "EnumWithNoOneOf.proto",
@@ -162,6 +175,8 @@ func configureSampleProtos() {
 	// ImportedEnum:
 	sampleProtos["ImportedEnum"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.ImportedEnum},
 		FilesToGenerate:    []string{"ImportedEnum.proto"},
 		ProtoFileName:      "ImportedEnum.proto",
@@ -170,6 +185,8 @@ func configureSampleProtos() {
 	// NestedMessage:
 	sampleProtos["NestedMessage"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage, testdata.NestedMessage},
 		FilesToGenerate:    []string{"NestedMessage.proto", "PayloadMessage.proto"},
 		ProtoFileName:      "NestedMessage.proto",
@@ -178,14 +195,28 @@ func configureSampleProtos() {
 	// NestedObject:
 	sampleProtos["NestedObject"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.NestedObject},
 		FilesToGenerate:    []string{"NestedObject.proto"},
 		ProtoFileName:      "NestedObject.proto",
 	}
 
+	// NoOneOf:
+	sampleProtos["NoOneOf"] = SampleProto{
+		AllowNullValues:    false,
+		AllowEnumOneOf:     false,
+		AllowOneOf:         false,
+		ExpectedJsonSchema: []string{testdata.NoOneOf},
+		FilesToGenerate:    []string{"NoOneOf.proto"},
+		ProtoFileName:      "NoOneOf.proto",
+	}
+
 	// PayloadMessage:
 	sampleProtos["PayloadMessage"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.PayloadMessage},
 		FilesToGenerate:    []string{"PayloadMessage.proto"},
 		ProtoFileName:      "PayloadMessage.proto",
@@ -194,6 +225,8 @@ func configureSampleProtos() {
 	// SeveralEnums:
 	sampleProtos["SeveralEnums"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.FirstEnum, testdata.SecondEnum},
 		FilesToGenerate:    []string{"SeveralEnums.proto"},
 		ProtoFileName:      "SeveralEnums.proto",
@@ -202,6 +235,8 @@ func configureSampleProtos() {
 	// SeveralMessages:
 	sampleProtos["SeveralMessages"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.FirstMessage, testdata.SecondMessage},
 		FilesToGenerate:    []string{"SeveralMessages.proto"},
 		ProtoFileName:      "SeveralMessages.proto",
@@ -210,6 +245,8 @@ func configureSampleProtos() {
 	// Timestamp
 	sampleProtos["Timestamp"] = SampleProto{
 		AllowNullValues:    false,
+		AllowEnumOneOf:     true,
+		AllowOneOf:         true,
 		ExpectedJsonSchema: []string{testdata.Timestamp},
 		FilesToGenerate:    []string{"Timestamp.proto"},
 		ProtoFileName:      "Timestamp.proto",

--- a/testdata/no_one_of.go
+++ b/testdata/no_one_of.go
@@ -1,0 +1,21 @@
+package testdata
+
+const NoOneOf = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "bigNumber": {
+            "type": "integer"
+        },
+        "someChoice": {
+            "enum": [
+                "FOO",
+                "BAR",
+                "FIZZ",
+                "BUZZ"
+            ],
+            "type": "string"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/testdata/proto/NoOneOf.proto
+++ b/testdata/proto/NoOneOf.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package samples;
+
+message NoOneOf {
+    enum inline {
+        FOO = 0;
+        BAR = 1;
+        FIZZ = 2;
+        BUZZ = 3;
+    }
+    
+    inline someChoice = 1;
+    int64 bigNumber = 2;
+}


### PR DESCRIPTION
There shouldn't be any oneOfs generated. This can cause problems in traversing the json schema in transchema plus we don't want the validator to allow anything with a oneOf in it