### PR TITLE
Fix external enums

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -42,21 +42,22 @@ func TestGenerateJsonSchema(t *testing.T) {
 	configureSampleProtos()
 
 	// Convert the protos, compare the results against the expected JSON-Schemas:
-	testConvertSampleProtos(t, sampleProtos["ArrayOfMessages"])
-	testConvertSampleProtos(t, sampleProtos["ArrayOfObjects"])
-	testConvertSampleProtos(t, sampleProtos["ArrayOfPrimitives"])
-	testConvertSampleProtos(t, sampleProtos["EnumCeption"])
-	testConvertSampleProtos(t, sampleProtos["EnumWithNoOneOf"])
-	testConvertSampleProtos(t, sampleProtos["ImportedEnum"])
-	testConvertSampleProtos(t, sampleProtos["NestedMessage"])
-	testConvertSampleProtos(t, sampleProtos["NestedMessageNoAdditionalProperties"])
-	testConvertSampleProtos(t, sampleProtos["NestedObject"])
-	testConvertSampleProtos(t, sampleProtos["NoOneOf"])
-	testConvertSampleProtos(t, sampleProtos["PayloadMessage"])
-	testConvertSampleProtos(t, sampleProtos["SeveralEnums"])
-	testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
-	testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
-	testConvertSampleProtos(t, sampleProtos["Timestamp"])
+	// testConvertSampleProtos(t, sampleProtos["ArrayOfMessages"])
+	// testConvertSampleProtos(t, sampleProtos["ArrayOfObjects"])
+	// testConvertSampleProtos(t, sampleProtos["ArrayOfPrimitives"])
+	// testConvertSampleProtos(t, sampleProtos["EnumCeption"])
+	// testConvertSampleProtos(t, sampleProtos["EnumWithNoOneOf"])
+	testConvertSampleProtos(t, sampleProtos["ExternalEnum"])
+	// testConvertSampleProtos(t, sampleProtos["ImportedEnum"])
+	// testConvertSampleProtos(t, sampleProtos["NestedMessage"])
+	// testConvertSampleProtos(t, sampleProtos["NestedMessageNoAdditionalProperties"])
+	// testConvertSampleProtos(t, sampleProtos["NestedObject"])
+	// testConvertSampleProtos(t, sampleProtos["NoOneOf"])
+	// testConvertSampleProtos(t, sampleProtos["PayloadMessage"])
+	// testConvertSampleProtos(t, sampleProtos["SeveralEnums"])
+	// testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
+	// testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
+	// testConvertSampleProtos(t, sampleProtos["Timestamp"])
 }
 
 func testForProtocBinary(t *testing.T) {
@@ -163,6 +164,16 @@ func configureSampleProtos() {
 		ExpectedJsonSchema: []string{testdata.EnumWithNoOneOf},
 		FilesToGenerate:    []string{"EnumWithNoOneOf.proto"},
 		ProtoFileName:      "EnumWithNoOneOf.proto",
+	}
+
+	// ExternalEnum:
+	sampleProtos["ExternalEnum"] = SampleProto{
+		AllowNullValues:    false,
+		DisallowEnumOneOf:  true,
+		DisallowOneOf:      true,
+		ExpectedJsonSchema: []string{testdata.ExternalEnum},
+		FilesToGenerate:    []string{"ExternalEnum.proto"},
+		ProtoFileName:      "ExternalEnum.proto",
 	}
 
 	// ImportedEnum:

--- a/main_test.go
+++ b/main_test.go
@@ -42,22 +42,23 @@ func TestGenerateJsonSchema(t *testing.T) {
 	configureSampleProtos()
 
 	// Convert the protos, compare the results against the expected JSON-Schemas:
-	// testConvertSampleProtos(t, sampleProtos["ArrayOfMessages"])
-	// testConvertSampleProtos(t, sampleProtos["ArrayOfObjects"])
-	// testConvertSampleProtos(t, sampleProtos["ArrayOfPrimitives"])
-	// testConvertSampleProtos(t, sampleProtos["EnumCeption"])
-	// testConvertSampleProtos(t, sampleProtos["EnumWithNoOneOf"])
+	testConvertSampleProtos(t, sampleProtos["ArrayOfMessages"])
+	testConvertSampleProtos(t, sampleProtos["ArrayOfObjects"])
+	testConvertSampleProtos(t, sampleProtos["ArrayOfPrimitives"])
+	testConvertSampleProtos(t, sampleProtos["EnumCeption"])
+	testConvertSampleProtos(t, sampleProtos["EnumWithNoOneOf"])
 	testConvertSampleProtos(t, sampleProtos["ExternalEnum"])
-	// testConvertSampleProtos(t, sampleProtos["ImportedEnum"])
-	// testConvertSampleProtos(t, sampleProtos["NestedMessage"])
-	// testConvertSampleProtos(t, sampleProtos["NestedMessageNoAdditionalProperties"])
-	// testConvertSampleProtos(t, sampleProtos["NestedObject"])
-	// testConvertSampleProtos(t, sampleProtos["NoOneOf"])
-	// testConvertSampleProtos(t, sampleProtos["PayloadMessage"])
-	// testConvertSampleProtos(t, sampleProtos["SeveralEnums"])
-	// testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
-	// testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
-	// testConvertSampleProtos(t, sampleProtos["Timestamp"])
+	testConvertSampleProtos(t, sampleProtos["ImportedExternalEnum"])
+	testConvertSampleProtos(t, sampleProtos["ImportedEnum"])
+	testConvertSampleProtos(t, sampleProtos["NestedMessage"])
+	testConvertSampleProtos(t, sampleProtos["NestedMessageNoAdditionalProperties"])
+	testConvertSampleProtos(t, sampleProtos["NestedObject"])
+	testConvertSampleProtos(t, sampleProtos["NoOneOf"])
+	testConvertSampleProtos(t, sampleProtos["PayloadMessage"])
+	testConvertSampleProtos(t, sampleProtos["SeveralEnums"])
+	testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
+	testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
+	testConvertSampleProtos(t, sampleProtos["Timestamp"])
 }
 
 func testForProtocBinary(t *testing.T) {
@@ -182,6 +183,16 @@ func configureSampleProtos() {
 		ExpectedJsonSchema: []string{testdata.ImportedEnum},
 		FilesToGenerate:    []string{"ImportedEnum.proto"},
 		ProtoFileName:      "ImportedEnum.proto",
+	}
+
+	// ImportedExternalEnum:
+	sampleProtos["ImportedExternalEnum"] = SampleProto{
+		AllowNullValues:    false,
+		DisallowEnumOneOf:  true,
+		DisallowOneOf:      true,
+		ExpectedJsonSchema: []string{testdata.ImportedExternalEnum},
+		FilesToGenerate:    []string{"ImportedExternalEnum.proto"},
+		ProtoFileName:      "ImportedExternalEnum.proto",
 	}
 
 	// NestedMessage:

--- a/testdata/enum_ception.go
+++ b/testdata/enum_ception.go
@@ -26,6 +26,16 @@ const EnumCeption = `{
             "type": "integer"
         },
         "importedEnum": {
+            "enum": [
+                "VALUE_0",
+                0,
+                "VALUE_1",
+                1,
+                "VALUE_2",
+                2,
+                "VALUE_3",
+                3
+            ],
             "oneOf": [
                 {
                     "type": "string"

--- a/testdata/external_enum.go
+++ b/testdata/external_enum.go
@@ -1,0 +1,26 @@
+package testdata
+
+const ExternalEnum = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "single": {
+            "enum": [
+                "FOO",
+                "BAR"
+            ],
+            "type": "string"
+        },
+        "stuff": {
+            "items": {
+                "enum": [
+                    "FOO",
+                    "BAR"
+                ],
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/testdata/imported_external_enum.go
+++ b/testdata/imported_external_enum.go
@@ -1,6 +1,6 @@
 package testdata
 
-const ExternalEnum = `{
+const ImportedExternalEnum = `{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "properties": {
         "repeat": {

--- a/testdata/proto/ExternalEnum.proto
+++ b/testdata/proto/ExternalEnum.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package samples;
+
+enum External {
+    FIZZ = 0;
+	BUZZ = 1;
+}
+
+message ExternalEnum {
+    External single = 1;
+    repeated External repeat = 2;
+}

--- a/testdata/proto/ExternalEnum.proto
+++ b/testdata/proto/ExternalEnum.proto
@@ -2,11 +2,11 @@ syntax = "proto3";
 package samples;
 
 enum External {
-    FIZZ = 0;
+  FIZZ = 0;
 	BUZZ = 1;
 }
 
 message ExternalEnum {
-    External single = 1;
-    repeated External repeat = 2;
+  External single = 1;
+  repeated External repeat = 2;
 }

--- a/testdata/proto/ImportedEnum.proto
+++ b/testdata/proto/ImportedEnum.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package samples;
 
 enum ImportedEnum {
-    VALUE_0 = 0;
+  VALUE_0 = 0;
 	VALUE_1 = 1;
 	VALUE_2 = 2;
 	VALUE_3 = 3;

--- a/testdata/proto/ImportedExternalEnum.proto
+++ b/testdata/proto/ImportedExternalEnum.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package samples;
+
+import "ExternalEnum.proto";
+
+message ImportedExternalEnum {
+  samples.External single = 1;
+  repeated samples.External repeat = 2;
+}


### PR DESCRIPTION
This PR resolves a bug in the library that prevents enum generation when the enum is defined outside the message (either in the same file or in a different file).

I added unit tests to ensure the functionality was working as expected.